### PR TITLE
Shelly TRV Support

### DIFF
--- a/shelly_exporter.py
+++ b/shelly_exporter.py
@@ -162,16 +162,24 @@ class Shelly:
             help="Percentage of battery level")
     metrics.add("bat_voltage", status["bat"]["voltage"],
             help="Battery voltage")
+    metrics.add("bat_charger", status["charger"],
+            help="Boolean to show whether a charger is plugged in")
     for i, r in enumerate(status["thermostats"]):
         labels = {"thermostats": str(i)}
         metrics.add("pos", r["pos"], labels=labels,
             help="Position of thermostat pin")
-        metrics.add("thermostat_target_t", r["target_t"]["value"], labels=labels,
-            help="Thermostat target temperature")
         metrics.add("thermostat_enabled", r["target_t"]["enabled"], labels=labels,
             help="Whether the thermostat is enabled")
-        metrics.add("tmp", r["tmp"]["value"], labels=labels,
+        metrics.add("thermostat_target_t", r["target_t"]["value"], labels=labels,
+            help="Thermostat target temperature")
+#        metrics.add("thermostat_target_unit", r["target_t"]["units"], labels=labels,
+#            help="Unit of the target temperature, either F or C")
+        metrics.add("thermostat_measured_temperature", r["tmp"]["value"], labels=labels,
             help="Thermostat measured temperature")
+#        metrics.add("thermostat_measured_unit", r["tmp"]["units"], labels=labels,
+#            help="Unit of the measured temperature, either F or C")
+        metrics.add("thermostat_measured_valid", r["tmp"]["is_valid"], labels=labels,
+                help="Whether the temperature measurement is valid")
         metrics.add("thermostat_is_scheduled", r["schedule"], labels=labels,
             help="Whether the thermostat is following a schedule")
         metrics.add("thermostat_schedule_profile", r["schedule_profile"], labels=labels,


### PR DESCRIPTION
Shelly recently released smart thermostat which are quite similiar to the shelly plugs. I've simply pulled up the relevant json and modified the get_metrics function accordingly. 

![image](https://user-images.githubusercontent.com/19466442/165099997-33efaf20-b749-41c2-a962-148898e30889.png)

There are two metrics which I couldn't add: The unit for the measured and targeted temperatures. Those are either "C" or "F", so the prometheus_client crashes as it can't convert those to floats:

```
2022-04-25 15:45:40 [FALCON] [ERROR] GET /metrics => Traceback (most recent call last):
  File "falcon/app.py", line 365, in falcon.app.App.__call__
  File "/home/jan/prometheus-shelly-exporter/shelly_exporter.py", line 227, in on_get
    resp.text = prom.exposition.generate_latest(metrics)
  File "/usr/lib/python3.10/site-packages/prometheus_client/exposition.py", line 228, in generate_latest
    output.append(sample_line(s))
  File "/usr/lib/python3.10/site-packages/prometheus_client/exposition.py", line 194, in sample_line
    return f'{line.name}{labelstr} {floatToGoString(line.value)}{timestamp}\n'
  File "/usr/lib/python3.10/site-packages/prometheus_client/utils.py", line 9, in floatToGoString
    d = float(d)
```
Anyway, I expect most users will set this once during setup to their preferred unit and never touch the setting again so I've just commented those metrics out.