### PR TITLE
Add Shelly H&T suport

### DIFF
--- a/shelly_exporter.py
+++ b/shelly_exporter.py
@@ -200,10 +200,8 @@ class Shelly:
             help="Air humidity, in %rH")
     metrics.add("humidity_valid", status["hum"]["is_valid"],
             help="Whether the humidity measurement is valid")
-    metrics.add("temperature_C", status["tmp"]["tC"],
-            help="Air temperature, in Celsius")
-    metrics.add("temperature_F", status["tmp"]["tF"],
-            help="Air temperature, in Fahrenheit")
+    metrics.add("temperature", status["tmp"]["value"],
+            help="Air temperature")
     metrics.add("temperature_valid", status["tmp"]["is_valid"],
             help="Whether the temperature measurement is valid")
     return metrics

--- a/shelly_exporter.py
+++ b/shelly_exporter.py
@@ -80,7 +80,7 @@ class Shelly:
     try:
       _path = re.sub(r'^/', '', path)
       url = f"http://{self.name}/{_path}"
-      req = requests.get(url, auth=self._auth)
+      req = requests.get(url, auth=self._auth, timeout=5)
       return req.json()
     except Exception as e:
       raise ShellyException(str(e))
@@ -188,11 +188,32 @@ class Shelly:
             help="Length of initial warm-up boost, in minutes")
     return metrics
 
+  def _get_metrics_HT(self):
+    metrics = self._get_metrics_base()
+    settings = self.api("/settings")
+    status = self.api("/status")
+    metrics.add("bat_charge", status["bat"]["value"],
+            help="Percentage of battery level")
+    metrics.add("bat_voltage", status["bat"]["voltage"],
+            help="Battery voltage")
+    metrics.add("humidity", status["hum"]["value"],
+            help="Air humidity, in %rH")
+    metrics.add("humidity_valid", status["hum"]["is_valid"],
+            help="Whether the humidity measurement is valid")
+    metrics.add("temperature_C", status["tmp"]["tC"],
+            help="Air temperature, in Celsius")
+    metrics.add("temperature_F", status["tmp"]["tF"],
+            help="Air temperature, in Fahrenheit")
+    metrics.add("temperature_valid", status["tmp"]["is_valid"],
+            help="Whether the temperature measurement is valid")
+    return metrics
+
 
   def get_metrics(self):
     getters = {
         "SHPLG-S":  self._get_metrics_plug,
-        "SHTRV-01": self._get_metrics_trv
+        "SHTRV-01": self._get_metrics_trv,
+        "SHHT-1":   self._get_metrics_HT
       }
     metrics = getters[self.type]() if self.type in getters.keys() else self._get_metrics_base()
     return metrics


### PR DESCRIPTION
Hi there!

I just added my Shelly H&T as well into the exporter.

There was a small issue where the exporter would poll the status from the H&T, which would then go offline on the next pull. The thing is, the router still remembers that there was a route to the device and thus this line:
```
req = requests.get(url, auth=self._auth
```
would be stuck for about a minute, as it wouldn't immediately fail with 'No route to host' as before. Therefore no other device could be pulled for a minute whenever the H&T decided to go online.

I fixed this by adding a 5s timeout to every request :)