### PR TITLE
Don't spam journald upon every scrape GET request

### DIFF
--- a/shelly_exporter.py
+++ b/shelly_exporter.py
@@ -362,6 +362,9 @@ class Static:
     resp.set_header('Content-Type', prom.exposition.CONTENT_TYPE_LATEST)
     resp.text = prom.exposition.generate_latest(metrics)
 
+class quietRequestHandler(simple_server.WSGIRequestHandler):
+    def log_message(self, format, *args):
+        pass
 
 def run(cfg):
   api = falcon.App()
@@ -370,7 +373,7 @@ def run(cfg):
   api.add_route('/metrics', Static(cfg['targetcfg'], cfg['static_targets'], cfg['username'],
     cfg['password'], metrics_file, cfg['timeout']))
   api.add_route('/probe', Prober(cfg['targetcfg'], metrics_file, cfg['timeout']))
-  httpd = simple_server.make_server(cfg['listen_ip'], cfg['listen_port'], api)
+  httpd = simple_server.make_server(cfg['listen_ip'], cfg['listen_port'], api, handler_class=quietRequestHandler)
   httpd.serve_forever()
 
 


### PR DESCRIPTION
Every time the Prometheus scraper makes an HTTP GET request I see this line on stdout:
```
127.0.0.1 - - [22/Sep/2022 17:51:19] "GET /metrics HTTP/1.1" 200 8104
```

I run the program as a systemd service, as such I see 4 such messages per minute in my journald afterwards which is quiet the nuisance.

By subclassing the `RequestHandler` and overriding the `log_message` function those messages won't be printed.