### PR TITLE
Fix CLI arg static targets

### DIFF
--- a/shelly_exporter.py
+++ b/shelly_exporter.py
@@ -454,7 +454,7 @@ Device-specific metrics are auto-discovered based on the 'type' value of the '/s
   else:
     if args.listen_ip: cfg['listen_ip'] = args.listen_ip
     if args.listen_port: cfg['listen_port'] = args.listen_port
-    if args.static_targets: cfg['static_targets'] = args.listen_port.split(',')
+    if args.static_targets: cfg['static_targets'] = args.static_targets.split(',')
     if args.username: cfg['username'] = args.username
     if args.password: cfg['password'] = args.password
     if args.timeout: cfg['timeout'] = args.timeout


### PR DESCRIPTION
I think this is a typo, if I supply static targets via `-s` I get the following error:
```
python shelly_exporter.py -p 9686 -s 192.168.178.110,192.168.178.111
Traceback (most recent call last):
  File "/tmp/prometheus-shelly-exporter/shelly_exporter.py", line 473, in <module>
    cli()
  File "/tmp/prometheus-shelly-exporter/shelly_exporter.py", line 457, in cli
    if args.static_targets: cfg['static_targets'] = args.listen_port.split(',')
AttributeError: 'int' object has no attribute 'split'
```
So it tries to do `listen_port.split(',')` when it should do `static_targets.split(',')`